### PR TITLE
MAYH-9062 fixed sqs `ackMessages`

### DIFF
--- a/antiope-core/package.yaml
+++ b/antiope-core/package.yaml
@@ -29,6 +29,7 @@ dependencies:
 - http-client
 - lens
 - mtl
+- resourcet
 - text
 - transformers
 

--- a/antiope-core/src/Antiope/Core.hs
+++ b/antiope-core/src/Antiope/Core.hs
@@ -17,8 +17,11 @@ module Antiope.Core
 )
 where
 
-import           Network.AWS.Data.Text (FromText (..), Text, ToText (..),
-                                        fromText, toText)
+import Control.Monad.Trans.Class    (lift)
+import Control.Monad.Trans.Resource (ResourceT)
+import Network.AWS.Data.Text        (FromText (..), Text, ToText (..), fromText, toText)
 
-import qualified Network.AWS           as AWS
+import qualified Network.AWS as AWS
 
+instance AWS.MonadAWS m => AWS.MonadAWS (ResourceT m) where
+  liftAWS = lift . AWS.liftAWS

--- a/antiope-s3/src/Antiope/S3.hs
+++ b/antiope-s3/src/Antiope/S3.hs
@@ -75,7 +75,7 @@ fromS3Uri uri = do
   let k = pack $ drop 1 $ puri & uriPath
   pure $ S3Uri (BucketName b) (ObjectKey k)
 
-downloadLBS :: (MonadResource m, MonadAWS m)
+downloadLBS :: MonadAWS m
             => BucketName
             -> ObjectKey
             -> m ByteString
@@ -83,7 +83,7 @@ downloadLBS bucketName objectKey = do
   resp <- send $ getObject bucketName objectKey
   (resp ^. gorsBody) `sinkBody` sinkLbs
 
-downloadLBS' :: (MonadResource m, MonadAWS m)
+downloadLBS' :: MonadAWS m
              => BucketName
              -> ObjectKey
              -> m (Maybe ByteString)
@@ -95,7 +95,7 @@ downloadLBS' bucketName objectKey = do
     Right bs -> return (Just bs)
     Left _   -> return Nothing
 
-downloadS3Uri :: (MonadResource m, MonadAWS m)
+downloadS3Uri :: MonadAWS m
               => S3Uri
               -> m (Maybe ByteString)
 downloadS3Uri (S3Uri b k) = downloadLBS' b k

--- a/antiope-sqs/src/Antiope/SQS.hs
+++ b/antiope-sqs/src/Antiope/SQS.hs
@@ -5,6 +5,7 @@ module Antiope.SQS
 , FromText(..), fromText
 , ToText(..)
 , QueueUrl(..)
+, SQSError(..)
 , readQueue
 , drainQueue
 , ackMessage
@@ -12,21 +13,24 @@ module Antiope.SQS
 , module Network.AWS.SQS
 ) where
 
-import           Control.Lens          ((&), (?~), (^.))
-import           Control.Monad         (forM_, join, void)
-import           Control.Monad.Loops   (unfoldWhileM)
-import           Network.AWS           (MonadAWS, send)
-import           Network.AWS.SQS
+import Control.Lens         (each, (&), (.~), (?~), (^.), (^..))
+import Control.Monad        (forM_, join, void, when)
+import Control.Monad.Except (ExceptT (..), throwError)
+import Control.Monad.Loops  (unfoldWhileM)
+import Data.Maybe           (catMaybes)
+import Network.AWS          (MonadAWS, send)
+import Network.AWS.SQS
 
-import           Data.String           (IsString)
-import           Data.Text             (Text)
-import           Network.AWS.Data.Text (FromText (..), ToText (..), fromText,
-                                        toText)
+import Data.String           (IsString)
+import Data.Text             (Text, pack)
+import Network.AWS.Data.Text (FromText (..), ToText (..), fromText, toText)
+
+data SQSError = DeleteMessageBatchError
 
 newtype QueueUrl = QueueUrl { unQueueUrl :: Text } deriving (Show, Eq, IsString, FromText, ToText)
 
 -- | Reads the specified SQS queue once returning a bath of messages
-readQueue :: (MonadAWS m) => QueueUrl -> m [Message]
+readQueue :: MonadAWS m => QueueUrl -> m [Message]
 readQueue (QueueUrl queueUrl) = do
   -- max wait time allowed by aws is 20sec, max number messages to recieve is 10
   resp <- send $ receiveMessage queueUrl & rmWaitTimeSeconds ?~ 10 & rmMaxNumberOfMessages ?~ 10
@@ -37,12 +41,17 @@ drainQueue :: MonadAWS m => QueueUrl -> m [Message]
 drainQueue queueUrl =
   join <$> unfoldWhileM (not . null) (readQueue queueUrl)
 
-ackMessage :: MonadAWS m => QueueUrl -> Message -> m ()
-ackMessage (QueueUrl queueUrl) msg =
-  case msg ^. mReceiptHandle of
-    Nothing -> pure ()
-    Just rc -> void . send $ deleteMessage queueUrl rc
+ackMessage :: MonadAWS m => QueueUrl -> Message -> ExceptT SQSError m ()
+ackMessage q msg = ackMessages q [msg]
 
-ackMessages :: MonadAWS m => QueueUrl -> [Message] -> m ()
-ackMessages queueUrl messages =
-  forM_ messages (ackMessage queueUrl)
+ackMessages :: MonadAWS m => QueueUrl -> [Message] -> ExceptT SQSError m ()
+ackMessages (QueueUrl queueUrl) msgs = do
+  let receipts = catMaybes $ msgs ^.. each . mReceiptHandle
+  -- each dmbr needs an ID. just use the list index.
+  let dmbres = (\(r, i) -> deleteMessageBatchRequestEntry (pack (show i)) r) <$> zip receipts ([0..] :: [Int])
+  resp <- send $ deleteMessageBatch queueUrl & dmbEntries .~ dmbres
+  -- only acceptable if no errors.
+  when (resp ^. dmbrsResponseStatus == 200) $
+      case resp ^. dmbrsFailed of
+        [] -> return ()
+        _  -> throwError DeleteMessageBatchError


### PR DESCRIPTION
```
type AWS = AWST (ResourceT IO)
```

```deleteMessage``` returns a type with nothing in it, therefore when parsing the AWS response, nothing in the HTTP body is evaluated. This leaves the body, and thus the actual HTTPS connection, unevaluated and not cleaned up, resulting in a connection leak that kills applications when their `ulimit` resources are exhausted.