### PR TITLE
MAYH-9336 antiope-sns

### DIFF
--- a/antiope-athena/package.yaml
+++ b/antiope-athena/package.yaml
@@ -44,6 +44,14 @@ dependencies:
 - text
 - transformers
 
+ghc-options:
+- -Wall
+- -Wcompat
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -O2
+- -msse4.2
+
 library:
   source-dirs: src
 

--- a/antiope-athena/src/Antiope/Athena.hs
+++ b/antiope-athena/src/Antiope/Athena.hs
@@ -10,7 +10,7 @@ import Control.Monad.Trans.Resource
 import Data.Text                    (Text)
 import Network.AWS                  (MonadAWS, await, send)
 import Network.AWS.Athena
-import Network.AWS.Waiter
+import Network.AWS.Waiter           hiding (accept)
 
 query :: (MonadResource m, MonadAWS m)
             => ResultConfiguration
@@ -27,8 +27,8 @@ query config context qstring clientRequestToken = do
     Nothing   -> return []
   where
     go qeid = do
-      accpt <- await queryExecutionFinished (getQueryExecution qeid)
-      case accpt of
+      accept <- await queryExecutionFinished (getQueryExecution qeid)
+      case accept of
         AcceptSuccess -> do
           results <- send $ getQueryResults qeid
           case view gqrrsResultSet results of

--- a/antiope-athena/src/Antiope/Athena.hs
+++ b/antiope-athena/src/Antiope/Athena.hs
@@ -1,30 +1,16 @@
 module Antiope.Athena
   ( query
+  , queryExecutionSucceed
   , module Network.AWS.Athena
   )where
 
-import           Control.Lens
-import           Control.Monad
-import           Control.Monad.Catch          (catch)
-import           Control.Monad.Morph          (hoist)
-import           Control.Monad.Trans.AWS      hiding (await, send)
-import           Control.Monad.Trans.Resource
-import qualified Data.ByteString              as BS
-import           Data.ByteString.Lazy         (ByteString, empty)
-import           Data.Conduit                 hiding (await)
-import           Data.Conduit.Binary          (sinkLbs)
-import           Data.Monoid                  ((<>))
-import           Data.Text                    (Text)
-import           Network.AWS                  (Error (..), MonadAWS,
-                                               ServiceError (..), await, send)
-import           Network.AWS.Athena
-import           Network.AWS.Athena.Types
-import           Network.AWS.Athena.Waiters
-import           Network.AWS.Data
-import           Network.AWS.Data.Body        (_streamBody)
-import           Network.AWS.Waiter
-import           Network.HTTP.Types.Status    (Status (..))
-
+import Control.Lens
+import Control.Monad.Trans.AWS      hiding (await, send)
+import Control.Monad.Trans.Resource
+import Data.Text                    (Text)
+import Network.AWS                  (MonadAWS, await, send)
+import Network.AWS.Athena
+import Network.AWS.Waiter
 
 query :: (MonadResource m, MonadAWS m)
             => ResultConfiguration
@@ -41,8 +27,8 @@ query config context qstring clientRequestToken = do
     Nothing   -> return []
   where
     go qeid = do
-      accept <- await queryExecutionFinished (getQueryExecution qeid)
-      case accept of
+      accpt <- await queryExecutionFinished (getQueryExecution qeid)
+      case accpt of
         AcceptSuccess -> do
           results <- send $ getQueryResults qeid
           case view gqrrsResultSet results of
@@ -75,4 +61,5 @@ queryExecutionSucceed qeid = do
   eq <- view gqersQueryExecution <$> send (getQueryExecution qeid)
   case view qesState =<< (view qeStatus =<< eq) of
     Just Succeeded -> return True
+    Just _         -> return False
     Nothing        -> return False

--- a/antiope-core/package.yaml
+++ b/antiope-core/package.yaml
@@ -33,6 +33,15 @@ dependencies:
 - text
 - transformers
 
+ghc-options:
+- -Wall
+- -Wcompat
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wredundant-constraints
+- -O2
+- -msse4.2
+
 library:
   source-dirs: src
 

--- a/antiope-core/src/Antiope/Core.hs
+++ b/antiope-core/src/Antiope/Core.hs
@@ -1,6 +1,8 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Antiope.Core
 ( module Network.AWS.Data.Text
-, AWS.Env(..)
+, AWS.Env
 , AWS.HasEnv(..)
 , AWS.MonadAWS
 , AWS.runAWS
@@ -8,7 +10,7 @@ module Antiope.Core
 , AWS.runResourceT
 , AWS.liftAWS
 , AWS.sinkMD5, AWS.sinkSHA256
-, AWS.AWS(..)
+, AWS.AWS
 , AWS.catching
 , AWS.Error(..)
 , AWS.ErrorCode(..), AWS.errorCode

--- a/antiope-core/src/Antiope/Env.hs
+++ b/antiope-core/src/Antiope/Env.hs
@@ -8,7 +8,6 @@ module Antiope.Env
 where
 
 import           Control.Lens
-import           Control.Monad
 import           Control.Monad.Trans.AWS       hiding (LogLevel)
 import qualified Data.ByteString               as BS
 import           Data.ByteString.Builder
@@ -16,23 +15,22 @@ import qualified Data.ByteString.Char8         as C8
 import qualified Data.ByteString.Lazy          as L
 import qualified Data.ByteString.Lazy.Internal as LBS
 
-import qualified Network.AWS                   as AWS
-import           Network.HTTP.Client           (HttpException (..),
-                                                HttpExceptionContent (..))
+import qualified Network.AWS         as AWS
+import           Network.HTTP.Client (HttpException (..), HttpExceptionContent (..))
 
 mkEnv :: Region -> (AWS.LogLevel -> LBS.ByteString -> IO ()) -> IO AWS.Env
-mkEnv region log = do
-  lgr <- newAwsLogger log
+mkEnv region lg = do
+  lgr <- newAwsLogger lg
   newEnv Discover
     <&> envLogger .~ lgr
     <&> envRegion .~ region
     <&> envRetryCheck .~ retryPolicy 5
 
 newAwsLogger :: Monad m => (AWS.LogLevel -> LBS.ByteString -> IO ()) -> m AWS.Logger
-newAwsLogger log = return $ \y b ->
+newAwsLogger lg = return $ \y b ->
   case toLazyByteString b of
     msg | BS.isInfixOf (C8.pack "404 Not Found") (L.toStrict msg) -> pure ()
-    msg -> log y msg
+    msg -> lg y msg
 
 retryPolicy :: Int -> Int -> HttpException -> Bool
 retryPolicy maxNum attempt ex = (attempt <= maxNum) && shouldRetry ex

--- a/antiope-dynamodb/package.yaml
+++ b/antiope-dynamodb/package.yaml
@@ -44,6 +44,15 @@ dependencies:
 - transformers
 - unordered-containers
 
+ghc-options:
+- -Wall
+- -Wcompat
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wredundant-constraints
+- -O2
+- -msse4.2
+
 library:
   source-dirs: src
 

--- a/antiope-dynamodb/src/Antiope/DynamoDB.hs
+++ b/antiope-dynamodb/src/Antiope/DynamoDB.hs
@@ -10,14 +10,13 @@ module Antiope.DynamoDB
 , module Network.AWS.DynamoDB
 ) where
 
-import           Control.Lens          ((&), (.~), (?~))
-import           Data.HashMap.Strict   (HashMap)
-import           Data.String           (IsString)
-import           Data.Text             (Text)
-import           Network.AWS           (MonadAWS, send)
-import           Network.AWS.Data.Text (FromText (..), ToText (..), fromText,
-                                        toText)
-import           Network.AWS.DynamoDB
+import Control.Lens          ((&), (.~))
+import Data.HashMap.Strict   (HashMap)
+import Data.String           (IsString)
+import Data.Text             (Text)
+import Network.AWS           (MonadAWS, send)
+import Network.AWS.Data.Text (FromText (..), ToText (..), fromText, toText)
+import Network.AWS.DynamoDB
 
 newtype TableName = TableName { unTableName :: Text } deriving (Eq, Show, IsString, ToText, FromText)
 

--- a/antiope-s3/package.yaml
+++ b/antiope-s3/package.yaml
@@ -46,6 +46,15 @@ dependencies:
 - text
 - transformers
 
+ghc-options:
+- -Wall
+- -Wcompat
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wredundant-constraints
+- -O2
+- -msse4.2
+
 library:
   source-dirs: src
 

--- a/antiope-s3/src/Antiope/S3.hs
+++ b/antiope-s3/src/Antiope/S3.hs
@@ -27,9 +27,7 @@ module Antiope.S3
 import Control.Lens
 import Control.Monad
 import Control.Monad.Catch          (catch)
-import Control.Monad.IO.Class       (liftIO)
-import Control.Monad.Logger         (LogStr (..), ToLogStr (..))
-import Control.Monad.Morph          (hoist)
+import Control.Monad.Logger         (ToLogStr (..))
 import Control.Monad.Trans.AWS      hiding (send)
 import Control.Monad.Trans.Resource
 import Data.ByteString.Lazy         (ByteString, empty)

--- a/antiope-sns/ChangeLog.md
+++ b/antiope-sns/ChangeLog.md
@@ -1,0 +1,3 @@
+# Changelog for antiope-sns
+
+## Unreleased changes

--- a/antiope-sns/LICENSE
+++ b/antiope-sns/LICENSE
@@ -1,0 +1,30 @@
+Copyright Arbor Networks (c) 2018
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Alexey Raga nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/antiope-sns/README.md
+++ b/antiope-sns/README.md
@@ -1,0 +1,1 @@
+# antiope-sns

--- a/antiope-sns/Setup.hs
+++ b/antiope-sns/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/antiope-sns/package.yaml
+++ b/antiope-sns/package.yaml
@@ -1,4 +1,4 @@
-name:                antiope-sqs
+name:                antiope-sns
 version:             1.0.0
 github:              "arbor/antiope"
 license:             MIT
@@ -31,9 +31,7 @@ dependencies:
 - aeson
 - amazonka
 - amazonka-core
-- amazonka-sqs
-- amazonka-s3
-- antiope-s3
+- amazonka-sns
 - bytestring
 - conduit-extra
 - exceptions
@@ -61,7 +59,7 @@ library:
   source-dirs: src
 
 tests:
-  antiope-sqs-test:
+  antiope-sns-test:
     main:                Spec.hs
     source-dirs:         test
     ghc-options:
@@ -69,4 +67,4 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - antiope-sqs
+    - antiope-sns

--- a/antiope-sns/src/Antiope/SNS.hs
+++ b/antiope-sns/src/Antiope/SNS.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Antiope.SNS
 ( MonadAWS
 , publishMsg

--- a/antiope-sns/src/Antiope/SNS.hs
+++ b/antiope-sns/src/Antiope/SNS.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Antiope.SNS
+( MonadAWS
+, publishMsg
+, subscribeMsg
+, module Network.AWS.SNS
+) where
+
+import Control.Lens
+import Data.Text       (Text)
+import Network.AWS     (MonadAWS, send)
+import Network.AWS.SNS
+
+publishMsg :: MonadAWS m => Text -> Text -> m ()
+publishMsg topicArn message = do
+  _ <- send $ publish message & pTopicARN ?~ topicArn
+  return ()
+
+subscribeMsg :: MonadAWS m => Text -> Text -> Text -> m ()
+subscribeMsg topicArn protocol ep = do
+  _ <- send $ subscribe topicArn protocol & subEndpoint ?~ ep
+  return ()
+

--- a/antiope-sns/test/Spec.hs
+++ b/antiope-sns/test/Spec.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"

--- a/antiope-sqs/src/Antiope/SQS.hs
+++ b/antiope-sqs/src/Antiope/SQS.hs
@@ -17,7 +17,7 @@ module Antiope.SQS
 
 import Antiope.S3            (S3Uri (..))
 import Control.Lens
-import Control.Monad         (forM_, join, void, when)
+import Control.Monad         (join)
 import Control.Monad.Loops   (unfoldWhileM)
 import Data.Aeson.Lens
 import Data.Maybe            (catMaybes)

--- a/antiope-sqs/src/Antiope/SQS.hs
+++ b/antiope-sqs/src/Antiope/SQS.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Antiope.SQS
 ( MonadAWS
 , FromText(..), fromText

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,7 @@ packages:
 - antiope-sqs
 - antiope-dynamodb
 - antiope-athena
+- antiope-sns
 
 - location:
     git: git@github.com:brendanhay/amazonka
@@ -15,4 +16,5 @@ packages:
       - amazonka-sqs
       - amazonka-dynamodb
       - amazonka-athena
+      - amazonka-sns
   extra-dep: true


### PR DESCRIPTION
* Added `antiope-sns`
* Added warnings and cleaned.

Test:
```
λ> env <- mkEnv Oregon (\l bs -> return ()) 
λ> runResourceT $ runAWS env $ publishMsg "arn:aws:sns:us-west-2:143032791481:wan-MaxMindRawTopic" "test"
it :: ()
```

And run 10s of `publishMsg`, check `lsof` to see whether there are leaked connection: looks like no.
```
λ> sequence_ $ [runResourceT $ runAWS env $ publishMsg "arn:aws:sns:us-west-2:143032791481:wan-MaxMindRawTopic" "test" | _ <- take 1000 [1..]]
jwan@~/Start/atlas/python $ lsof -p 38158  | wc -l
     153
jwan@~/Start/atlas/python $ lsof -p 38158  | wc -l
     153
```

```
runResourceT $ runAWS env $ sequence_ $ [publishMsg "arn:aws:sns:us-west-2:143032791481:wan-MaxMindRawTopic" "test" | _ <- take 1000 [1..]]

jwan@~/Start/atlas/python $ lsof -p 38158  | wc -l
     153
```

