### PR TITLE
Add s3 ls bucket response stream function

### DIFF
--- a/antiope-athena/package.yaml
+++ b/antiope-athena/package.yaml
@@ -1,5 +1,5 @@
 name:                antiope-athena
-version:             6.0.1
+version:             6.0.2
 github:              "arbor/antiope"
 license:             MIT
 category:            Services

--- a/antiope-core/package.yaml
+++ b/antiope-core/package.yaml
@@ -1,5 +1,5 @@
 name:                antiope-core
-version:             6.0.1
+version:             6.0.2
 github:              "arbor/antiope"
 license:             MIT
 category:            Services

--- a/antiope-dynamodb/package.yaml
+++ b/antiope-dynamodb/package.yaml
@@ -1,5 +1,5 @@
 name:                antiope-dynamodb
-version:             6.0.1
+version:             6.0.2
 github:              "arbor/antiope"
 license:             MIT
 category:            Services

--- a/antiope-messages/package.yaml
+++ b/antiope-messages/package.yaml
@@ -1,5 +1,5 @@
 name:                antiope-messages
-version:             6.0.1
+version:             6.0.2
 github:              "arbor/antiope"
 license:             MIT
 category:            Services

--- a/antiope-s3/package.yaml
+++ b/antiope-s3/package.yaml
@@ -1,5 +1,5 @@
 name:                antiope-s3
-version:             6.0.1
+version:             6.0.2
 github:              "arbor/antiope"
 license:             MIT
 category:            Services

--- a/antiope-sns/package.yaml
+++ b/antiope-sns/package.yaml
@@ -1,5 +1,5 @@
 name:                antiope-sns
-version:             6.0.1
+version:             6.0.2
 github:              "arbor/antiope"
 license:             MIT
 category:            Services

--- a/antiope-sqs/package.yaml
+++ b/antiope-sqs/package.yaml
@@ -1,5 +1,5 @@
 name:                antiope-sqs
-version:             6.0.1
+version:             6.0.2
 github:              "arbor/antiope"
 license:             MIT
 category:            Services


### PR DESCRIPTION
If we want to extract from ls response something other than Objects with (^. lovrsContents) then we need stream of Responses.

That's for extraction of (^. lovrsCommonPrefixes) in s3-to-sqs