### PR TITLE
bucket/objectKey should not be empty

### DIFF
--- a/antiope-s3/src/Antiope/S3.hs
+++ b/antiope-s3/src/Antiope/S3.hs
@@ -38,7 +38,7 @@ import Network.AWS.Data
 import Network.AWS.Data.Body        (_streamBody)
 import Network.AWS.S3
 import Network.HTTP.Types.Status    (Status (..))
-import Network.URI                  (URI (..), URIAuth (..), parseURI)
+import Network.URI                  (URI (..), URIAuth (..), parseURI, unEscapeString)
 
 import qualified Data.ByteString as BS
 import qualified Network.AWS     as AWS
@@ -50,13 +50,13 @@ fromS3Uri :: Text -> Maybe S3Uri
 fromS3Uri uri = do
   puri <- parseURI (unpack uri)
   auth <- puri & uriAuthority
-  let b = pack $ auth & uriRegName       -- URI lib is pretty weird
-  let k = pack $ drop 1 $ puri & uriPath
+  let b = pack $ unEscapeString $ auth & uriRegName       -- URI lib is pretty weird
+  let k = pack $ unEscapeString $ drop 1 $ puri & uriPath
   S3Uri <$> (BucketName <$> checkEmpty b)
         <*> (ObjectKey <$> checkEmpty k)
   where
     checkEmpty t
-      | T.null t    = Nothing
+      | T.null t  = Nothing
       | otherwise = Just t
 
 downloadLBS :: MonadAWS m


### PR DESCRIPTION
This is to fix:
```
λ> fromS3Uri "s3:///"
Just (S3Uri {bucket = BucketName "", objectKey = ObjectKey ""})
it :: Maybe S3Uri
(0.01 secs, 1,298,072 bytes)
```
After fix:
```
λ> fromS3Uri "s3:///"
Nothing
it :: Maybe S3Uri
(0.24 secs, 1,666,008 bytes)

λ> fromS3Uri "s3://testbucket/year%3D3/month%3D5"
Just (S3Uri {bucket = BucketName "testbucket", objectKey = ObjectKey "year=3/month=5"})
it :: Maybe S3Uri
(0.05 secs, 1,779,328 bytes)
λ> fromS3Uri "s3://testbucket/year=3/month=5/day=7/test.file"
Just (S3Uri {bucket = BucketName "testbucket", objectKey = ObjectKey "year=3/month=5/day=7/test.file"})
it :: Maybe S3Uri
(0.01 secs, 1,820,248 bytes)

```