### PR TITLE
MAYH-9790 fix Read for S3Uri

### DIFF
--- a/antiope-s3/src/Antiope/S3/Types.hs
+++ b/antiope-s3/src/Antiope/S3/Types.hs
@@ -65,9 +65,9 @@ readBucketName = do
 -- As per: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
 readObjectKey :: RP.ReadPrec ObjectKey
 readObjectKey = do
-  objKey <- tail <$> readWhile (/= ' ')
-  when (length objKey <= 0 || length objKey > 1024) RP.pfail
-  return (ObjectKey (T.pack objKey))
+  objKey <- readWhile (/= ' ')
+  when (length objKey <= 1 || length objKey > 1025) RP.pfail
+  return (ObjectKey (T.pack $ drop 1 objKey))
 
 instance Read S3Uri where
   readsPrec = RP.readPrec_to_S $ do

--- a/antiope-s3/src/Antiope/S3/Types.hs
+++ b/antiope-s3/src/Antiope/S3/Types.hs
@@ -62,9 +62,15 @@ readBucketName = do
   return (BucketName (T.pack bucketName))
   where bucketNameChar c = isLower c || isDigit c || c == '.' || c == '-'
 
+-- As per: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+readObjectKey :: RP.ReadPrec ObjectKey
+readObjectKey = do
+  objKey <- tail <$> readWhile (/= ' ')
+  when (length objKey <= 0 || length objKey > 1024) RP.pfail
+  return (ObjectKey (T.pack objKey))
+
 instance Read S3Uri where
   readsPrec = RP.readPrec_to_S $ do
     _  <- readString "s3://"
     bn <- readBucketName
-    ok <- ObjectKey . T.pack <$> readWhile (/= ' ')
-    return (S3Uri bn ok)
+    S3Uri bn <$> readObjectKey


### PR DESCRIPTION
Problem:
```
λ> read "s3://test/" :: AS.S3Uri
S3Uri {bucket = BucketName "test", objectKey = ObjectKey "/"}
it :: S3Uri
(0.01 secs, 1,273,216 bytes)
λ> read "s3://test" :: AS.S3Uri
S3Uri {bucket = BucketName "test", objectKey = ObjectKey ""}
it :: S3Uri
(0.01 secs, 1,274,232 bytes)
```
With the fix:
```
λ> read "s3://test" :: AS.S3Uri
*** Exception: Prelude.read: no parse
λ> read "s3://test/" :: AS.S3Uri
*** Exception: Prelude.read: no parse
λ> read "s3://test/3" :: AS.S3Uri
S3Uri {bucket = BucketName "test", objectKey = ObjectKey "3"}
it :: S3Uri
(0.01 secs, 1,691,576 bytes)
λ>
```