### PR TITLE
Operator to append text to S3Uri

### DIFF
--- a/antiope-s3/antiope-s3.cabal
+++ b/antiope-s3/antiope-s3.cabal
@@ -31,6 +31,7 @@ library
       Antiope.S3.Range
       Antiope.S3.Request
       Antiope.S3.Strict
+      Antiope.S3.Syntax
       Antiope.S3.Types
   hs-source-dirs: src
   default-extensions: BangPatterns GeneralizedNewtypeDeriving OverloadedStrings TupleSections

--- a/antiope-s3/src/Antiope/S3/Syntax.hs
+++ b/antiope-s3/src/Antiope/S3/Syntax.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Antiope.S3.Syntax
+  ( (</>)
+  ) where
+
+import Antiope.S3.Types
+import Control.Lens
+import Data.Generics.Product.Any
+import Data.Text                 (Text)
+
+-- | Append text to an S3Uri
+(</>) :: S3Uri -> Text -> S3Uri
+(</>) uri suffix = uri & the @"objectKey" . the @1 %~ (<> ("/" <> suffix))


### PR DESCRIPTION
In a separate module because this is the same operator from `filepath` library so code may not always want to import it.