### PR TITLE
Use newtypes for messages

### DIFF
--- a/antiope-athena/antiope-athena.cabal
+++ b/antiope-athena/antiope-athena.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:               antiope-athena
-version:            7.1.2
+version:            7.2.0
 synopsis:           Please see the README on Github at <https://github.com/arbor/antiope#readme>
 description:        Please see the README on Github at <https://github.com/arbor/antiope#readme>.
 category:           Services

--- a/antiope-contract/antiope-contract.cabal
+++ b/antiope-contract/antiope-contract.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:               antiope-contract
-version:            7.1.2
+version:            7.2.0
 synopsis:           Please see the README on Github at <https://github.com/arbor/antiope#readme>
 description:        Please see the README on Github at <https://github.com/arbor/antiope#readme>.
 category:           Services

--- a/antiope-core/antiope-core.cabal
+++ b/antiope-core/antiope-core.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:               antiope-core
-version:            7.1.2
+version:            7.2.0
 description:        Please see the README on Github at <https://github.com/arbor/antiope#readme>.
 synopsis:           Please see the README on Github at <https://github.com/arbor/antiope#readme>
 category:           Services

--- a/antiope-dynamodb/antiope-dynamodb.cabal
+++ b/antiope-dynamodb/antiope-dynamodb.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:               antiope-dynamodb
-version:            7.1.2
+version:            7.2.0
 synopsis:           Please see the README on Github at <https://github.com/arbor/antiope#readme>
 description:        Please see the README on Github at <https://github.com/arbor/antiope#readme>.
 category:           Services

--- a/antiope-messages/antiope-messages.cabal
+++ b/antiope-messages/antiope-messages.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:               antiope-messages
-version:            7.1.2
+version:            7.2.0
 synopsis:           Please see the README on Github at <https://github.com/arbor/antiope#readme>
 description:        Please see the README on Github at <https://github.com/arbor/antiope#readme>.
 category:           Services

--- a/antiope-optparse-applicative/antiope-optparse-applicative.cabal
+++ b/antiope-optparse-applicative/antiope-optparse-applicative.cabal
@@ -1,6 +1,6 @@
 cabal-version:        2.2
 name:                 antiope-optparse-applicative
-version:              7.1.2
+version:              7.2.0
 synopsis:             Please see the README on Github at <https://github.com/arbor/antiope#readme>
 description:          Please see the README on Github at <https://github.com/arbor/antiope#readme>.
 category:             Services

--- a/antiope-s3/antiope-s3.cabal
+++ b/antiope-s3/antiope-s3.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:               antiope-s3
-version:            7.1.2
+version:            7.2.0
 synopsis:           Please see the README on Github at <https://github.com/arbor/antiope#readme>
 description:        Please see the README on Github at <https://github.com/arbor/antiope#readme>.
 category:           Services

--- a/antiope-s3/src/Antiope/S3/Messages.hs
+++ b/antiope-s3/src/Antiope/S3/Messages.hs
@@ -10,7 +10,7 @@ module Antiope.S3.Messages
 
 import Antiope.Messages
 import Antiope.S3            (BucketName (..), ETag (..), ObjectKey (..))
-import Control.Lens          (each, to, (^..), _Just)
+import Control.Lens          (coerced, each, (^.))
 import Data.Aeson            as Aeson
 import Data.Int              (Int64)
 import Data.Text             (Text)
@@ -23,15 +23,14 @@ import qualified Data.Text          as T
 import qualified Data.Text.Encoding as T
 import qualified Network.URI        as URI
 
+
 messageToS3Uri :: S3Message -> Types.S3Uri
 messageToS3Uri msg = Types.S3Uri (bucket msg) (key msg)
 
 fromSnsRecords :: Text -> [S3Message]
 fromSnsRecords msg =
   Aeson.decodeStrict' @(WithEncoded "Message" (With "Records" [S3Message])) (T.encodeUtf8 msg)
-    ^.. _Just
-    . to fromWith2
-    . each
+    ^. each . coerced
 
 data EventName = EventName
   { eventType :: !Text

--- a/antiope-sns/antiope-sns.cabal
+++ b/antiope-sns/antiope-sns.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:               antiope-sns
-version:            7.1.2
+version:            7.2.0
 synopsis:           Please see the README on Github at <https://github.com/arbor/antiope#readme>
 description:        Please see the README on Github at <https://github.com/arbor/antiope#readme>.
 category:           Services

--- a/antiope-sqs/antiope-sqs.cabal
+++ b/antiope-sqs/antiope-sqs.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:               antiope-sqs
-version:            7.1.2
+version:            7.2.0
 synopsis:           Please see the README on Github at <https://github.com/arbor/antiope#readme>
 description:        Please see the README on Github at <https://github.com/arbor/antiope#readme>.
 category:           Services


### PR DESCRIPTION
## Changes

Simplify `With` and `WithEncoded` types to use `newtype`.
This allows these types to be coercible to their representation, and also unlocks `deriving via`:

```haskell
newtype LambdaMessage a = LambdaMessage [[a]]
  deriving (Show, Generic)
  deriving FromJSON via (With "Records" [WithEncoded "body" (WithEncoded "Message" (With "Records" [a]))])

handler :: (MonadReader AppEnv m, MonadIO m)
  => LambdaMessage S3Message
  -> m Text
handler val = do
  undefined
```