### PR TITLE
Fix flaky test

### DIFF
--- a/antiope-sns/test/Antiope/SNS/MessagesSpec.hs
+++ b/antiope-sns/test/Antiope/SNS/MessagesSpec.hs
@@ -42,6 +42,6 @@ genUTCTime = do
   m <- Gen.int (Range.constant 1 12)
   d <- Gen.int (Range.constant 1 28)
   let day = fromGregorian y m d
-  secs <- toInteger <$> Gen.int (Range.constant 0 86401)
+  secs <- toInteger <$> Gen.int (Range.constant 0 86400)
   let diffTime = secondsToDiffTime secs
   pure $ UTCTime day diffTime


### PR DESCRIPTION
To fix this:

```
Antiope.S3.Messages
  Antiope.S3.MessagesSpec
  ✗ <interactive> failed at test/Antiope/S3/MessagesSpec.hs:66:5
    after 31 tests and 21 shrinks.
  
       ┏━━ test/Antiope/S3/MessagesSpec.hs ━━━
    62 ┃ spec :: Spec
    63 ┃ spec = describe "Antiope.S3.MessagesSpec" $ do
    64 ┃   it "Can encode and decode S3Message" $ require $ property $ do
    65 ┃     msg <- forAll $ s3Message
       ┃     │ S3Message
       ┃     │   { eventTime = (Just 2000 (-01) (-01) 23 : 59 : 61) UTC
       ┃     │   , eventName = EventName { eventType = "a" , action = "a" }
       ┃     │   , bucket = BucketName "a"
       ┃     │   , key = ObjectKey "year=2000/month=1/day=1/a"
       ┃     │   , size = 0
       ┃     │   , eTag = Nothing
       ┃     │   }
    66 ┃     tripping msg encode decode
       ┃     ^^^^^^^^^^^^^^^^^^^^^^^^^^
       ┃     │ ━━━ Intermediate ━━━
       ┃     │ "{\"eventTime\":\"2000-01-01T23:59:61Z\",\"s3\":{\"bucket\":{\"name\":\"a\"},\"object\":{\"eTag\":null,\"size\":0,\"key\":\"year=2000/month=1/day=1/a\"}},\"eventName\":\"a:a\"}"
       ┃     │ ━━━ - Original) (+ Roundtrip ━━━
       ┃     │ - Just
       ┃     │ -   S3Message
       ┃     │ -     { eventTime = (Just 2000 (-01) (-01) 23 : 59 : 61) UTC
       ┃     │ -     , eventName = EventName { eventType = "a" , action = "a" }
       ┃     │ -     , bucket = BucketName "a"
       ┃     │ -     , key = ObjectKey "year=2000/month=1/day=1/a"
       ┃     │ -     , size = 0
       ┃     │ -     , eTag = Nothing
       ┃     │ -     }
       ┃     │ + Nothing
  
    This failure can be reproduced by running:
    > recheck (Size 30) (Seed 1090838183401657058 14566175050054692341) <property>
```